### PR TITLE
ColorByApplyingShadow() enabled and GetTypeface() modified.

### DIFF
--- a/Sample/PaintCodeResources/PaintCodeClasses.cs
+++ b/Sample/PaintCodeResources/PaintCodeClasses.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 //using VectorCodeResources.Fonts;
@@ -540,9 +541,9 @@ namespace PaintCode
             return colorByBlendingColors(color, ratio, colorByChangingAlpha(Helpers.ColorWhite, color.Alpha));
         }
 
-        //public static int colorByApplyingShadow(int color, float ratio)
-        //{
-        //    return colorByBlendingColors(color, ratio, colorByChangingAlpha(Helpers.ColorBlack, Color.GetAlphaComponent(color)));
-        //}
+        public static SKColor colorByApplyingShadow(SKColor color, float ratio)
+        {
+            return colorByBlendingColors(color, ratio, colorByChangingAlpha(Helpers.ColorBlack, color.Alpha));
+        }
     }
 }

--- a/Sample/PaintCodeResources/PaintCodeClasses.cs
+++ b/Sample/PaintCodeResources/PaintCodeClasses.cs
@@ -112,6 +112,18 @@ namespace PaintCode
             var assembly = Assembly.GetExecutingAssembly();
 
             var stream = assembly.GetManifestResourceStream("PaintCodeResources.Fonts." + fullFontName);
+            
+            if (stream == null)
+            {
+                if (typefaceCache.Count != 0)
+                    return typefaceCache.FirstOrDefault().Value;
+
+                stream = assembly.GetManifestResourceStream("PaintCodeResources.Fonts.SF-UI-Display-Regular.otf");
+            }
+
+            if (stream == null)
+                return null;
+
             result = SKTypeface.FromStream(stream);
 
             typefaceCache[fullFontName] = result;


### PR DESCRIPTION
ColorByApplyingShadow() was missing.
+
I was getting crashes in GetTypeface() if I missed a font in Assemblies folder. In this case it takes one from cache or SF-UI-Display-Regular.otf as default.
